### PR TITLE
Add privacy policy and terms pages for Twilio A2P 10DLC campaign

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -120,3 +120,115 @@ main {
 }
 
 /**************************************************************************/
+
+/* Legal pages (Privacy Policy, Terms) */
+.nav-legal {
+    background: transparent;
+    box-shadow: none;
+    padding: 1rem 0;
+}
+
+.nav-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--primary-2);
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.nav-brand:hover {
+    color: var(--accent);
+}
+
+.legal-content {
+    padding-top: 1rem;
+    padding-bottom: 4rem;
+    max-width: 800px;
+}
+
+.legal-content h1 {
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 2.4rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.legal-content h2 {
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--primary-2);
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.legal-content p,
+.legal-content li {
+    font-family: "Inter", sans-serif;
+    color: var(--muted);
+    line-height: 1.75;
+    font-size: 1rem;
+}
+
+.legal-content ul {
+    padding-left: 1.25rem;
+}
+
+.legal-content li {
+    margin-bottom: 0.5rem;
+    list-style-type: disc;
+}
+
+.legal-content a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.legal-content a:hover {
+    color: var(--primary-2);
+}
+
+.legal-content section {
+    margin-bottom: 1rem;
+}
+
+.text-muted {
+    color: var(--muted);
+    font-size: 0.95rem;
+    margin-bottom: 2rem;
+}
+
+.contact-block {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+    margin-top: 0.5rem;
+}
+
+.contact-block p {
+    margin: 0.25rem 0;
+}
+
+.footer-links {
+    display: flex;
+    gap: 1.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.footer-links a {
+    color: var(--muted);
+    font-size: 0.9rem;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+    color: var(--accent);
+}

--- a/index.html
+++ b/index.html
@@ -134,6 +134,10 @@
     <div class="container">
         <h5>Taqueria Baez</h5>
         <p>Where every salsa tells a spicy story!</p>
+        <div class="footer-links">
+            <a href="/privacy-policy">Privacy Policy</a>
+            <a href="/terms">Terms &amp; Conditions</a>
+        </div>
     </div>
     <div class="footer-copyright p-0">
         <div class="container center">&copy; 2025 Taqueria Baez LLC</div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description"
+          content="Taqueria Baez Privacy Policy. Learn how we collect, use, and protect your personal information including SMS and text messaging data."/>
+    <meta name="robots" content="index, follow"/>
+    <meta name="theme-color" content="#6a1b9a"/>
+    <link rel="canonical" href="https://www.taqueriabaez.com/privacy-policy"/>
+
+    <link rel="icon" type="image/x-icon" href="./assets/img/favicon.ico"/>
+    <link rel="apple-touch-icon" sizes="180x180" href="./assets/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./assets/img/favicon-16x16.png">
+    <link rel="manifest" href="./assets/img/site.webmanifest">
+    <title>Privacy Policy | Taqueria Baez</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@500;600&display=swap"
+          rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/css/materialize.min.css">
+    <link rel="stylesheet" href="./assets/css/main.css">
+</head>
+
+<body>
+
+<nav class="nav-legal">
+    <div class="container">
+        <a href="/" class="nav-brand">
+            <i class="material-icons">arrow_back</i>
+            Taqueria Baez
+        </a>
+    </div>
+</nav>
+
+<main class="container legal-content">
+    <h1>Privacy Policy</h1>
+    <p class="text-muted">Effective Date: June 5, 2025 &mdash; Last Updated: June 5, 2025</p>
+
+    <section>
+        <h2>1. Introduction</h2>
+        <p>
+            Taqueria Baez LLC ("Taqueria Baez," "we," "us," or "our") operates the website
+            <strong>www.taqueriabaez.com</strong> and related services including SMS/text messaging programs.
+            This Privacy Policy describes how we collect, use, disclose, and protect your personal information
+            when you visit our website, dine with us, place orders, or interact with our text messaging services.
+        </p>
+        <p>
+            By using our website or services, you agree to the practices described in this Privacy Policy.
+            If you do not agree, please do not use our services.
+        </p>
+    </section>
+
+    <section>
+        <h2>2. Information We Collect</h2>
+        <p>We may collect the following types of personal information:</p>
+        <ul>
+            <li><strong>Contact Information:</strong> Name and phone number when you place an order by phone or text us.</li>
+            <li><strong>Order Information:</strong> Details of your food orders, payment method (cash or card), and order history.</li>
+            <li><strong>SMS/Text Messaging Data:</strong> Your mobile phone number, opt-in/opt-out status, message delivery and engagement data (such as delivery receipts), and the content of messages you send to us (e.g., STOP, HELP, or keyword responses).</li>
+            <li><strong>Device and Usage Information:</strong> Browser type, IP address, pages visited, and referring URLs when you visit our website.</li>
+            <li><strong>Location Information:</strong> General location data derived from your IP address or voluntarily provided when requesting directions to our restaurant.</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>3. How We Use Your Information</h2>
+        <p>We use the information we collect for the following purposes:</p>
+        <ul>
+            <li>To process and fulfill your food orders</li>
+            <li>To send you order confirmations, pickup notifications, and order status updates via SMS</li>
+            <li>To send announcements about our restaurant, including new locations and changes to operating hours</li>
+            <li>To respond to your inquiries and provide customer support</li>
+            <li>To improve our website, services, and customer experience</li>
+            <li>To comply with legal obligations</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>4. SMS/Text Messaging Privacy</h2>
+        <p>
+            When you opt in to receive text messages from Taqueria Baez, we collect your mobile phone number
+            and messaging engagement data. This information is used solely for the purpose of sending you text
+            messages related to our restaurant services.
+        </p>
+        <p>
+            <strong>No mobile information will be shared with third parties or affiliates for
+            marketing or promotional purposes.</strong>
+        </p>
+        <p>
+            Your mobile phone number, SMS consent, and any information collected through our text messaging
+            program will not be sold, rented, loaned, traded, or otherwise shared with or disclosed to any
+            third parties or affiliates for their marketing or promotional purposes. We may share your
+            information with service providers who assist us in delivering text messages (such as our messaging
+            platform provider), but only to the extent necessary to operate the messaging program and subject
+            to confidentiality obligations.
+        </p>
+        <p>
+            We use your phone number to send text messages related to orders you place by phone.
+            If you reply STOP, we will not send you any further messages.
+        </p>
+    </section>
+
+    <section>
+        <h2>5. Information Sharing and Disclosure</h2>
+        <p>We do not sell your personal information. We may share your information only in the following circumstances:</p>
+        <ul>
+            <li><strong>Service Providers:</strong> We work with third-party service providers who help us operate our business (e.g., payment processors, messaging platforms, website hosting). These providers are contractually obligated to protect your information and may only use it to perform services on our behalf.</li>
+            <li><strong>Legal Requirements:</strong> We may disclose your information if required by law, regulation, legal process, or governmental request.</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>6. Data Security</h2>
+        <p>
+            We implement reasonable administrative, technical, and physical safeguards to protect your
+            personal information from unauthorized access, use, alteration, or destruction. However, no
+            method of transmission over the internet or electronic storage is completely secure, and we
+            cannot guarantee absolute security.
+        </p>
+    </section>
+
+    <section>
+        <h2>7. Your Rights and Choices</h2>
+        <ul>
+            <li><strong>Opt Out of SMS:</strong> You may opt out of receiving text messages at any time by replying <strong>STOP</strong> to any message. You will receive a one-time confirmation of your opt-out.</li>
+            <li><strong>SMS Help:</strong> Reply <strong>HELP</strong> to any text message for assistance, or contact us directly.</li>
+            <li><strong>Access and Deletion:</strong> You may contact us to request access to, correction of, or deletion of your personal information.</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>8. Changes to This Privacy Policy</h2>
+        <p>
+            We may update this Privacy Policy from time to time. Changes will be posted on this page with
+            an updated "Last Updated" date. Your continued use of our services after any changes constitutes
+            your acceptance of the updated policy.
+        </p>
+    </section>
+
+    <section>
+        <h2>9. Contact Us</h2>
+        <p>If you have questions about this Privacy Policy or our data practices, please contact us:</p>
+        <div class="contact-block">
+            <p><strong>Taqueria Baez LLC</strong></p>
+            <p>2020 Azle Ave, Fort Worth, TX 76164</p>
+            <p>Phone: <a href="tel:+16822307062">(682) 230-7062</a></p>
+        </div>
+    </section>
+</main>
+
+<footer class="page-footer mt-0 pt-2">
+    <div class="container">
+        <h5>Taqueria Baez</h5>
+        <p>Where every salsa tells a spicy story!</p>
+        <div class="footer-links">
+            <a href="/privacy-policy">Privacy Policy</a>
+            <a href="/terms">Terms &amp; Conditions</a>
+        </div>
+    </div>
+    <div class="footer-copyright p-0">
+        <div class="container center">&copy; 2025 Taqueria Baez LLC</div>
+    </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/js/materialize.min.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,16 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://taqueriabaez.com/privacy-policy</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://taqueriabaez.com/terms</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description"
+          content="Taqueria Baez SMS Terms and Conditions. Review the terms for our text messaging program including message frequency, opt-out instructions, and data rates."/>
+    <meta name="robots" content="index, follow"/>
+    <meta name="theme-color" content="#6a1b9a"/>
+    <link rel="canonical" href="https://www.taqueriabaez.com/terms"/>
+
+    <link rel="icon" type="image/x-icon" href="./assets/img/favicon.ico"/>
+    <link rel="apple-touch-icon" sizes="180x180" href="./assets/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./assets/img/favicon-16x16.png">
+    <link rel="manifest" href="./assets/img/site.webmanifest">
+    <title>Terms &amp; Conditions | Taqueria Baez</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@500;600&display=swap"
+          rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/css/materialize.min.css">
+    <link rel="stylesheet" href="./assets/css/main.css">
+</head>
+
+<body>
+
+<nav class="nav-legal">
+    <div class="container">
+        <a href="/" class="nav-brand">
+            <i class="material-icons">arrow_back</i>
+            Taqueria Baez
+        </a>
+    </div>
+</nav>
+
+<main class="container legal-content">
+    <h1>SMS Terms &amp; Conditions</h1>
+    <p class="text-muted">Effective Date: June 5, 2025 &mdash; Last Updated: June 5, 2025</p>
+
+    <section>
+        <h2>1. Program Name</h2>
+        <p>
+            <strong>Taqueria Baez Text Updates</strong> &mdash; operated by Taqueria Baez LLC.
+        </p>
+    </section>
+
+    <section>
+        <h2>2. What You Are Signing Up For</h2>
+        <p>
+            By opting in to Taqueria Baez text messages, you agree to receive recurring automated text
+            messages from Taqueria Baez at the mobile number you provided. Messages may include:
+        </p>
+        <ul>
+            <li>Order confirmations and pickup notifications</li>
+            <li>Order status updates</li>
+            <li>Announcements about new restaurant locations and changes to operating hours</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>3. Message Frequency</h2>
+        <p>
+            Message frequency varies. You will receive text messages when your order is ready for
+            pickup, in reply to texts you send us, or on rare occasions for important restaurant
+            announcements (such as changes to hours or location).
+        </p>
+    </section>
+
+    <section>
+        <h2>4. Cost</h2>
+        <p>
+            <strong>Message and data rates may apply.</strong> Taqueria Baez does not charge you for
+            text messages, but your mobile carrier's standard messaging and data rates may apply.
+            Check with your carrier for details about your messaging plan.
+        </p>
+    </section>
+
+    <section>
+        <h2>5. Consent</h2>
+        <p>
+            Your consent to receive text messages is <strong>not a condition of any purchase</strong>.
+            You are free to purchase food and services from Taqueria Baez without opting in to our
+            text messaging program. You may opt out at any time.
+        </p>
+    </section>
+
+    <section>
+        <h2>6. How to Opt Out</h2>
+        <p>
+            To stop receiving text messages from Taqueria Baez, reply <strong>STOP</strong> to any
+            message you receive from us. You may also text STOP to our phone number at any time.
+        </p>
+        <p>
+            After opting out, you will receive a one-time confirmation message and will no longer
+            receive text messages from us.
+        </p>
+        <p>
+            Reply <strong>HELP</strong> for assistance or call <a href="tel:+16822307062">(682) 230-7062</a>.
+        </p>
+    </section>
+
+    <section>
+        <h2>7. Privacy</h2>
+        <p>
+            Your privacy is important to us. Your mobile phone number and personal information will
+            not be sold, rented, or shared with third parties or affiliates for marketing or promotional
+            purposes. Please see our full <a href="/privacy-policy">Privacy Policy</a> for details
+            on how we collect, use, and protect your information.
+        </p>
+    </section>
+
+    <section>
+        <h2>8. Disclaimer</h2>
+        <p>
+            Taqueria Baez is not responsible for any charges from your mobile carrier related to
+            text messaging. Taqueria Baez reserves the right to modify, suspend, or discontinue
+            the text messaging program at any time without notice. In the event of program
+            termination, you will receive a final notification message.
+        </p>
+    </section>
+
+    <section>
+        <h2>9. Contact Us</h2>
+        <div class="contact-block">
+            <p><strong>Taqueria Baez LLC</strong></p>
+            <p>2020 Azle Ave, Fort Worth, TX 76164</p>
+            <p>Phone: <a href="tel:+16822307062">(682) 230-7062</a></p>
+        </div>
+    </section>
+</main>
+
+<footer class="page-footer mt-0 pt-2">
+    <div class="container">
+        <h5>Taqueria Baez</h5>
+        <p>Where every salsa tells a spicy story!</p>
+        <div class="footer-links">
+            <a href="/privacy-policy">Privacy Policy</a>
+            <a href="/terms">Terms &amp; Conditions</a>
+        </div>
+    </div>
+    <div class="footer-copyright p-0">
+        <div class="container center">&copy; 2025 Taqueria Baez LLC</div>
+    </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/js/materialize.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Required for A2P 10DLC campaign registration. Includes TCPA/CTIA-compliant SMS privacy disclosures, opt-out instructions, and the critical "no mobile information shared with third parties" language. Footer updated with links on all pages, sitemap updated.