### PR TITLE
Redesign site to light "Find Us" theme; unify legal pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A small static site for **Taqueria Baez**, a Fort Worth, TX taco truck: a light, mobile-first home/"Find Us" page (`index.html`) plus two SMS-compliance legal pages (`privacy-policy.html`, `terms.html`). Pure HTML + CSS — no build step, no JavaScript framework, no package manager, no tests. The home page content tracks the business's phase (git history: "coming soon" → "we're moving" → the current permanent "Find us at 2020 Azle Ave").
+
+## Develop & preview
+
+There is nothing to compile. Edit files and reload the browser.
+
+```bash
+# Serve locally (browser caches CDN assets; a server avoids file:// quirks)
+python3 -m http.server 8000   # then open http://localhost:8000
+```
+
+## Deploy
+
+Hosted on **GitHub Pages** with the custom domain in `CNAME` (`www.taqueriabaez.com`). Pushing to `main` publishes the site — there is no CI/build. Active branches: `main` (live), `dev`, `dev-hector`. Do work on a branch and merge to `main` to ship.
+
+## Architecture
+
+- **`index.html`** — the home page: a light, mobile-first "Find Us" layout (slim header → "Find us at…" hero → three fact rows for location/phone/hours → action buttons → embedded Google Map → tagline → footer). No framework: layout is hand-written CSS and icons are **inline SVG** (no icon font). A small inline `<script>` at the bottom is progressive enhancement only — it flips the hours pill to live "Open now"/"Closed now" in `America/Chicago`; the page is fully functional with JS disabled.
+- **`privacy-policy.html` / `terms.html`** — SMS/text-messaging legal pages required for **Twilio A2P 10DLC** campaign registration. They share `main.css` and the same light theme and footer as the home page. Their body copy is TCPA/CTIA compliance language (STOP/HELP opt-out, "no mobile information shared with third parties") — treat it as legally reviewed; don't reword disclosures casually. Linked from every page's footer (`.footer-links`), which is itself a compliance requirement.
+- **`assets/css/main.css`** — the entire theme for all pages, hand-written (no Materialize). The light palette is driven entirely by CSS custom properties in `:root` (`--bg`, `--surface`, `--text`, `--muted`, `--hairline`, `--accent`, `--accent-text`, `--accent-tint`, `--status-green`); change colors there, not in individual rules. `--accent` (salsa red `#D7382B`) is the single accent for fills/icons/borders; `--accent-text` (`#BC2A20`) is the darker variant for link/button **text** so it clears WCAG AA contrast; `--status-green` is reserved for the functional Open-now pill only. The legal-page styles (`.container`, `.nav-legal`, `.legal-content`, `.contact-block`, `.footer-links`) live at the bottom of the file.
+- **The embedded map** uses the keyless `https://www.google.com/maps?q=...&output=embed` iframe (no API key). The address text + "Get Directions"/"Open in Google Maps" links are the source of truth and work independently of the iframe.
+- **`assets/img/`** — favicons, app icons, logo, and `site.webmanifest`. **`assets/fonts/`** — the bundled **Anton** display font, loaded via `@font-face` in `main.css` and used only for the wordmark and tagline (body text is Inter; headline is Space Grotesk, both still from Google Fonts).
+
+## Keep SEO/business data in sync (most important gotcha)
+
+The business's address, hours, and phone number are **duplicated in several places** and must be updated together whenever the details change:
+
+- `index.html` visible content (the hero `<h1>` and the three fact rows).
+- `index.html` `<meta name="description">` and `<meta name="keywords">`.
+- `index.html` Schema.org **JSON-LD** block (`@type: FoodEstablishment`) — `address`, `geo` lat/long, `openingHoursSpecification`, `telephone`, `priceRange`.
+- The address/phone also appear in the footer of all three pages and inside both legal pages' "Contact Us" blocks.
+- `sitemap.xml` — update `<lastmod>` on content changes.
+
+Every absolute URL uses the **`www`** host: `CNAME`, every page's `<link rel="canonical">`, the `url`/`image` fields in the JSON-LD, and all `<loc>` entries in `sitemap.xml` must stay on `https://www.taqueriabaez.com/`. `google0c6849f8c12510a3.html` is a Google Search Console verification token — do not rename or remove it.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,200 +1,447 @@
+/* Taqueria Baez — light, minimal "Find Us" page. Hand-written, no framework. */
+
+/* Bundled display font (reused local asset; no extra network request) */
+@font-face {
+    font-family: "Anton";
+    src: url("../fonts/Anton-Regular.ttf") format("truetype");
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+
 :root {
-    --bg: #0f1518;
-    --primary: #6a1b9a;
-    --primary-2: #c07bff;
-    --accent: #48d5c8;
-    --card: #132025;
-    --text: #f8f4ef;
-    --muted: #cfd6d9;
-    --chip: rgba(106, 27, 154, 0.16);
+    --bg: #FBFAF7;          /* warm off-white / bone */
+    --surface: #FFFFFF;     /* header, fact rows, map wrapper */
+    --text: #1C1A17;        /* warm near-black */
+    --muted: #6B6157;       /* secondary text */
+    --hairline: #ECE7DF;    /* borders / dividers */
+    --accent: #D7382B;      /* salsa red — the one accent (fills, borders, icons) */
+    --accent-text: #BC2A20; /* darker accent for text/links — clears WCAG AA (>=4.5:1) on bg/white/tint */
+    --accent-tint: #FBE7E0; /* soft circle behind icons, tagline band */
+    --status-green: #2E7D32;/* functional only: "Open now" pill */
 }
 
 * {
     box-sizing: border-box;
 }
 
-.text-primary-2 {
-    color: var(--primary-2);
+html {
+    -webkit-text-size-adjust: 100%;
 }
 
 body {
-    font-family: "Space Grotesk", "Inter", sans-serif;
-    background: radial-gradient(140% 140% at 20% 20%, rgba(106, 27, 154, 0.2), transparent),
-    radial-gradient(120% 120% at 80% 10%, rgba(72, 213, 200, 0.14), transparent),
-    radial-gradient(140% 140% at 80% 80%, rgba(192, 123, 255, 0.18), transparent),
-    var(--bg);
+    margin: 0;
+    background: var(--bg);
     color: var(--text);
+    font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+a {
+    color: var(--accent-text);
+}
+
+/* Keyboard focus visibility */
+a:focus-visible,
+.btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 6px;
+}
+
+/* ---------- Header ---------- */
+.site-header {
     display: flex;
-    min-height: 100vh;
-    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    height: 56px;
+    padding: 0 20px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--hairline);
+}
+
+.brand-logo {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.brand-wordmark {
+    font-family: "Anton", "Space Grotesk", sans-serif;
+    font-size: 20px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+/* ---------- Layout wrapper ---------- */
+.wrap {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 24px 20px 8px;
+}
+
+/* ---------- Hero statement ---------- */
+.hero {
+    margin: 4px 0 20px;
+}
+
+.hero-title {
+    font-family: "Space Grotesk", "Inter", sans-serif;
+    font-weight: 700;
+    font-size: clamp(26px, 7vw, 32px);
+    line-height: 1.15;
     margin: 0;
 }
 
-main {
-    flex: 1 0 auto;
+.hero-sub {
+    margin: 4px 0 0;
+    color: var(--muted);
+    font-size: 16px;
 }
 
-.flex{
+/* ---------- Fact rows ---------- */
+.facts {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.fact {
     display: flex;
     align-items: center;
+    gap: 14px;
+    min-height: 64px;
+    padding: 14px 16px;
+    background: var(--surface);
+    border: 1px solid var(--hairline);
+    border-radius: 14px;
+    text-decoration: none;
+    color: var(--text);
 }
 
-.wrap{
-    flex-wrap: wrap;
+.fact-link {
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 
-.badge-inline {
+.fact-link:hover {
+    border-color: var(--accent);
+    box-shadow: 0 6px 18px rgba(215, 56, 43, 0.10);
+}
+
+.fact-link:active {
+    transform: scale(0.995);
+}
+
+.fact-icon {
+    flex: 0 0 auto;
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    background: rgba(106, 27, 154, 0.15);
-    border: 1px solid rgba(106, 27, 154, 0.35);
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--accent-tint);
+    color: var(--accent);
+}
+
+.fact-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.fact-primary {
+    font-size: 18px;
+    font-weight: 600;
     color: var(--text);
-    padding: 1rem 1.5rem;
-    border-radius: 1.5rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+}
+
+.fact-secondary {
+    font-size: 14px;
+    color: var(--muted);
+}
+
+.fact-chevron {
+    flex: 0 0 auto;
+    color: var(--muted);
+    display: inline-flex;
+    align-items: center;
+}
+
+/* Hours status pill — neutral baseline; JS may upgrade to live status */
+.status-pill {
+    flex: 0 0 auto;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: #F1ECE4;
+    color: var(--muted);
+    white-space: nowrap;
+}
+
+.status-pill.is-open {
+    background: rgba(46, 125, 50, 0.12);
+    color: var(--status-green);
+}
+
+.status-pill.is-closed {
+    background: #F1ECE4;
+    color: var(--muted);
+}
+
+/* Hours row: keep the day & time on one line (never wrap the text); the status
+   pill sits beside it on wide screens and drops to its own right-aligned line
+   when space is tight, instead of squeezing and wrapping "Thursday–Sunday". */
+.fact-hours {
+    flex-wrap: wrap;
+    row-gap: 8px;
+}
+
+.fact-hours .fact-body {
+    flex-shrink: 0;
+}
+
+.fact-hours .status-pill {
+    margin-left: auto;
+}
+
+/* ---------- Action buttons ---------- */
+.actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 16px;
+}
+
+.btn {
+    flex: 1 1 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 50px;
+    padding: 0 18px;
+    border-radius: 12px;
+    font-size: 16px;
+    font-weight: 600;
+    text-decoration: none;
+    text-align: center;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
 .btn-primary {
-    background: linear-gradient(130deg, var(--primary), var(--primary-2));
-    color: var(--text);
-    font-weight: 700;
-    padding: 14px 18px;
-    border-radius: 12px;
-    border: none;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    box-shadow: 0 12px 30px rgba(106, 27, 154, 0.45);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background: var(--accent);
+    color: #FFFFFF;
+    box-shadow: 0 8px 20px rgba(215, 56, 43, 0.28);
 }
 
 .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 16px 40px rgba(106, 27, 154, 0.55);
+    transform: translateY(-1px);
+    box-shadow: 0 12px 26px rgba(215, 56, 43, 0.34);
 }
 
-.btn-ghost {
-    border: 1px solid rgba(255, 255, 255, 0.18);
-    color: var(--text);
-    padding: 12px 16px;
-    border-radius: 12px;
-    font-weight: 600;
-    background: rgba(255, 255, 255, 0.03);
+.btn-secondary {
+    background: var(--surface);
+    color: var(--accent-text);
+    border: 1px solid var(--accent);
 }
 
-.card {
-    background: linear-gradient(120deg, rgba(19, 32, 37, 0.92), rgba(19, 32, 37, 0.86));
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 18px;
-    padding: 24px;
-    backdrop-filter: blur(4px);
-    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.25);
-    position: relative;
+.btn-secondary:hover {
+    background: var(--accent-tint);
+}
+
+/* ---------- Map ---------- */
+.map {
+    margin-top: 24px;
+    text-align: center;
+}
+
+.map-frame {
+    border: 1px solid var(--hairline);
+    border-radius: 16px;
     overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+    line-height: 0;
 }
 
-.card::after {
-    content: "";
-    position: absolute;
-    inset: -40% auto auto -20%;
-    width: 240px;
-    height: 240px;
-    background: radial-gradient(circle, rgba(106, 27, 154, 0.18), transparent 55%);
-    transform: rotate(-10deg);
-    filter: blur(1px);
+.map-frame iframe {
+    display: block;
+    width: 100%;
+    height: 260px;
+    border: 0;
 }
 
-.card-title {
+.map-link {
+    display: inline-block;
+    margin-top: 10px;
     font-size: 14px;
+    font-weight: 600;
+    color: var(--accent-text);
+}
+
+/* ---------- Tagline band ---------- */
+.tagline-band {
+    margin-top: 32px;
+    padding: 28px 20px;
+    background: var(--accent-tint);
+    text-align: center;
+}
+
+.tagline-band p {
+    margin: 0 auto;
+    max-width: 640px;
+    font-family: "Anton", "Space Grotesk", sans-serif;
+    font-size: clamp(20px, 5vw, 26px);
+    letter-spacing: 0.5px;
+    color: var(--accent);
     text-transform: uppercase;
-    letter-spacing: 0.18em;
+}
+
+/* ---------- Footer ---------- */
+.site-footer {
+    padding: 24px 20px 32px;
+    text-align: center;
     color: var(--muted);
-    margin-bottom: 10px;
 }
 
-.card-panel {
-    background: rgba(255, 255, 255, 0.03);
-    border-radius: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.06);
+.site-footer p {
+    margin: 2px 0;
+    font-size: 14px;
 }
 
-/**************************************************************************/
+.footer-name {
+    font-weight: 600;
+    color: var(--text);
+    font-size: 16px !important;
+}
 
-/* Legal pages (Privacy Policy, Terms) */
+.footer-copy {
+    margin-top: 12px !important;
+    font-size: 12px !important;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 379px) {
+    .actions {
+        flex-direction: column;
+    }
+}
+
+@media (min-width: 700px) {
+    .map-frame iframe {
+        height: 320px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        transition: none !important;
+    }
+}
+
+/* ---------- Footer legal links (home + legal pages) ---------- */
+.footer-links {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin: 10px 0 2px;
+}
+
+.footer-links a {
+    color: var(--accent-text);
+    font-size: 14px;
+    text-decoration: none;
+}
+
+.footer-links a:hover {
+    text-decoration: underline;
+}
+
+/* ---------- Legal pages (Privacy Policy, Terms) ---------- */
+.container {
+    width: 100%;
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
 .nav-legal {
-    background: transparent;
-    box-shadow: none;
-    padding: 1rem 0;
+    background: var(--surface);
+    border-bottom: 1px solid var(--hairline);
 }
 
 .nav-brand {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    color: var(--primary-2);
-    font-family: "Space Grotesk", sans-serif;
+    height: 56px;
+    color: var(--text);
+    font-family: "Space Grotesk", "Inter", sans-serif;
     font-weight: 700;
-    font-size: 1.1rem;
+    font-size: 1rem;
     text-decoration: none;
-    transition: color 0.2s ease;
 }
 
-.nav-brand:hover {
+.nav-brand svg {
     color: var(--accent);
 }
 
+.nav-brand:hover {
+    color: var(--accent-text);
+}
+
 .legal-content {
-    padding-top: 1rem;
-    padding-bottom: 4rem;
-    max-width: 800px;
+    padding-top: 8px;
+    padding-bottom: 56px;
 }
 
 .legal-content h1 {
-    font-family: "Space Grotesk", sans-serif;
-    font-size: 2.4rem;
+    font-family: "Space Grotesk", "Inter", sans-serif;
+    font-size: clamp(28px, 6vw, 36px);
     font-weight: 700;
-    margin-bottom: 0.25rem;
+    margin: 16px 0 4px;
 }
 
 .legal-content h2 {
-    font-family: "Space Grotesk", sans-serif;
-    font-size: 1.4rem;
+    font-family: "Space Grotesk", "Inter", sans-serif;
+    font-size: 1.3rem;
     font-weight: 700;
-    color: var(--primary-2);
-    margin-top: 2.5rem;
-    margin-bottom: 0.75rem;
+    color: var(--text);
+    margin: 2.25rem 0 0.6rem;
 }
 
 .legal-content p,
 .legal-content li {
-    font-family: "Inter", sans-serif;
     color: var(--muted);
     line-height: 1.75;
-    font-size: 1rem;
+}
+
+.legal-content strong {
+    color: var(--text);
 }
 
 .legal-content ul {
     padding-left: 1.25rem;
+    margin: 0.5rem 0 0;
 }
 
 .legal-content li {
     margin-bottom: 0.5rem;
-    list-style-type: disc;
+    list-style: disc;
 }
 
 .legal-content a {
-    color: var(--accent);
+    color: var(--accent-text);
     text-decoration: underline;
     text-underline-offset: 3px;
 }
 
-.legal-content a:hover {
-    color: var(--primary-2);
-}
-
 .legal-content section {
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
 .text-muted {
@@ -204,31 +451,15 @@ main {
 }
 
 .contact-block {
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: var(--surface);
+    border: 1px solid var(--hairline);
     border-radius: 12px;
     padding: 1.25rem 1.5rem;
-    margin-top: 0.5rem;
+    margin-top: 0.75rem;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.04);
 }
 
 .contact-block p {
     margin: 0.25rem 0;
-}
-
-.footer-links {
-    display: flex;
-    gap: 1.5rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-}
-
-.footer-links a {
-    color: var(--muted);
-    font-size: 0.9rem;
-    text-decoration: none;
-    transition: color 0.2s ease;
-}
-
-.footer-links a:hover {
-    color: var(--accent);
+    color: var(--text);
 }

--- a/assets/img/site.webmanifest
+++ b/assets/img/site.webmanifest
@@ -1,1 +1,20 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Taqueria Baez",
+  "short_name": "Taqueria Baez",
+  "start_url": "/",
+  "icons": [
+    {
+      "src": "/assets/img/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/img/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#D7382B",
+  "background_color": "#FBFAF7",
+  "display": "standalone"
+}

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description"
-          content="Taqueria Baez is moving to a new location at 2020 Azle Ave in Fort Worth, TX. Visit us for fresh, authentic Mexican tacos!"/>
+          content="Taqueria Baez serves fresh, authentic Mexican tacos at 2020 Azle Ave, Fort Worth, TX. Open Thursday–Sunday, 6:00–11:00 PM. Call (682) 230-7062 or get directions."/>
     <meta name="keywords"
-          content="Taqueria Baez, Mexican food, tacos, Fort Worth, food truck, authentic Mexican cuisine"/>
+          content="Taqueria Baez, Mexican food, tacos, Fort Worth, food truck, authentic Mexican cuisine, 2020 Azle Ave"/>
     <meta name="author" content="Taqueria Baez"/>
     <meta name="robots" content="index, follow"/>
-    <meta name="theme-color" content="#6a1b9a"/>
+    <meta name="theme-color" content="#D7382B"/>
 
     <!-- Local SEO & Geotagging -->
     <meta name="geo.region" content="US-TX"/>
@@ -24,27 +24,23 @@
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="./assets/img/favicon-16x16.png">
     <link rel="manifest" href="./assets/img/site.webmanifest">
-    <title>Taqueria Baez | We Are Moving</title>
+    <title>Taqueria Baez | Tacos in Fort Worth — 2020 Azle Ave</title>
 
-    <!-- Fonts & Icons -->
+    <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@500;600&display=swap"
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600&display=swap"
           rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <!-- Materialize CSS -->
-    <link rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/css/materialize.min.css">
     <link rel="stylesheet" href="./assets/css/main.css">
 
     <!-- Schema.org Structured Data -->
     <script type="application/ld+json">
         {
             "@context": "https://schema.org",
-            "@type": "Food Truck",
+            "@type": "FoodEstablishment",
             "name": "Taqueria Baez",
-            "image": "https://taqueriabaez.com/assets/img/logo.png",
+            "image": "https://www.taqueriabaez.com/assets/img/logo.png",
             "url": "https://www.taqueriabaez.com/",
             "telephone": "+16822307062",
             "address": {
@@ -78,72 +74,143 @@
 </head>
 <body>
 
-<main class="container valign-wrapper">
+<header class="site-header">
+    <img class="brand-logo" src="./assets/img/logo.png" alt="Taqueria Baez logo" width="40" height="40">
+    <span class="brand-wordmark">Taqueria Baez</span>
+</header>
 
-    <section class="row">
-        <div class="col s12 l8">
-            <h3 class="badge-inline">
-                <i class="material-icons large">local_fire_department</i>
-                <span>We’re moving</span>
-            </h3>
-            <h1>Fresh tacos, new corner. Taqueria Baez is rolling to 2020 Azle ave in Fort Worth, TX.</h1>
-            <h5>
-                Pin the new spot, call the truck, and come try us at our new location.
-            </h5>
-            <div class="flex wrap mt-4 g-3">
-                <a class="btn-large btn-primary"
-                   href="https://www.google.com/maps/dir/?api=1&destination=2020%20azle%20ave%20fort%20worth%20tx"
-                   target="_blank" rel="noopener">Get
-                    directions</a>
-                <a class="btn-large btn-ghost " href="tel:+16822307062">Call the truck</a>
-            </div>
-        </div>
+<main class="wrap">
 
-        <div class="card col s12 l4">
-            <div class="card-content p-0">
-                <span class="card-title center-align">New address</span>
-                <div class="row g-1">
-                    <div class="col s12">
-                        <div class="card-panel">
-                            <div class="badge-inline"><i class="material-icons tiny">pin_drop</i>Location</div>
-                            <h5 class="text-primary-2">2020 Azle Ave.</h5>
-                            <p>Fort Worth, TX</p>
-                        </div>
-                    </div>
-                    <div class="col s12">
-                        <div class="card-panel">
-                            <div class="badge-inline"><i class="material-icons tiny">event</i> Goes live</div>
-                            <h5><strong>Thursday, December 4</strong></h5>
-                        </div>
-                    </div>
-                    <div class="col s12">
-                        <div class="card-panel">
-                            <div class="badge-inline"><i class="material-icons tiny">schedule</i> Hours</div>
-                            <h5><strong>Thursday - Sunday</strong></h5>
-                            <p>6:00 PM – 11:00 PM</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <section class="hero">
+        <h1 class="hero-title">Find us at 2020 Azle Ave</h1>
+        <p class="hero-sub">Fort Worth, TX</p>
     </section>
+
+    <section class="facts" aria-label="Where and when to find us">
+
+        <!-- Location -->
+        <a class="fact fact-link"
+           href="https://www.google.com/maps/dir/?api=1&amp;destination=2020+Azle+Ave+Fort+Worth+TX+76164"
+           target="_blank" rel="noopener"
+           aria-label="Get directions to 2020 Azle Ave, Fort Worth, TX 76164">
+            <span class="fact-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+                    <path d="M21 10c0 6-9 12-9 12s-9-6-9-12a9 9 0 0 1 18 0z"></path>
+                    <circle cx="12" cy="10" r="3"></circle>
+                </svg>
+            </span>
+            <span class="fact-body">
+                <span class="fact-primary">2020 Azle Ave</span>
+                <span class="fact-secondary">Fort Worth, TX 76164</span>
+            </span>
+            <span class="fact-chevron" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+                    <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+            </span>
+        </a>
+
+        <!-- Phone -->
+        <a class="fact fact-link" href="tel:+16822307062"
+           aria-label="Call Taqueria Baez at (682) 230-7062">
+            <span class="fact-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+                    <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"></path>
+                </svg>
+            </span>
+            <span class="fact-body">
+                <span class="fact-primary">(682) 230-7062</span>
+                <span class="fact-secondary">Tap to call</span>
+            </span>
+            <span class="fact-chevron" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+                    <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+            </span>
+        </a>
+
+        <!-- Hours (informational, not a link) -->
+        <div class="fact fact-hours">
+            <span class="fact-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+                    <circle cx="12" cy="12" r="9"></circle>
+                    <polyline points="12 7 12 12 16 14"></polyline>
+                </svg>
+            </span>
+            <span class="fact-body">
+                <span class="fact-primary">Thursday–Sunday</span>
+                <span class="fact-secondary"><time datetime="18:00">6:00 PM</time> – <time datetime="23:00">11:00 PM</time></span>
+            </span>
+            <span id="status-pill" class="status-pill">Open Thu–Sun</span>
+        </div>
+
+    </section>
+
+    <div class="actions">
+        <a class="btn btn-primary"
+           href="https://www.google.com/maps/dir/?api=1&amp;destination=2020+Azle+Ave+Fort+Worth+TX+76164"
+           target="_blank" rel="noopener">Get Directions</a>
+        <a class="btn btn-secondary" href="tel:+16822307062">Call</a>
+    </div>
+
+    <section class="map" aria-label="Map of our location">
+        <div class="map-frame">
+            <iframe
+                src="https://www.google.com/maps?q=2020+Azle+Ave+Fort+Worth+TX+76164&amp;output=embed"
+                title="Map showing Taqueria Baez at 2020 Azle Ave, Fort Worth, TX"
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+                allowfullscreen></iframe>
+        </div>
+        <a class="map-link"
+           href="https://www.google.com/maps/search/?api=1&amp;query=2020+Azle+Ave+Fort+Worth+TX+76164"
+           target="_blank" rel="noopener">Open in Google Maps</a>
+    </section>
+
 </main>
 
+<section class="tagline-band">
+    <p>Where every salsa tells a spicy story!</p>
+</section>
 
-<footer class="page-footer mt-0 pt-2">
-    <div class="container">
-        <h5>Taqueria Baez</h5>
-        <p>Where every salsa tells a spicy story!</p>
-        <div class="footer-links">
-            <a href="/privacy-policy">Privacy Policy</a>
-            <a href="/terms">Terms &amp; Conditions</a>
-        </div>
-    </div>
-    <div class="footer-copyright p-0">
-        <div class="container center">&copy; 2025 Taqueria Baez LLC</div>
-    </div>
+<footer class="site-footer">
+    <p class="footer-name">Taqueria Baez</p>
+    <p class="footer-address">2020 Azle Ave, Fort Worth, TX 76164</p>
+    <p><a href="tel:+16822307062">(682) 230-7062</a></p>
+    <p class="footer-meta">$ · Mexican · Food Truck</p>
+    <nav class="footer-links" aria-label="Legal">
+        <a href="/privacy-policy">Privacy Policy</a>
+        <a href="/terms">Terms &amp; Conditions</a>
+    </nav>
+    <p class="footer-copy">&copy; 2026 Taqueria Baez LLC</p>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/js/materialize.min.js"></script>
+<script>
+    // Progressive enhancement: show live Open/Closed against the Thu–Sun 6–11 PM
+    // schedule in the truck's local time (America/Chicago). The plain-text hours
+    // above remain authoritative; if anything fails we keep the neutral pill.
+    (function () {
+        try {
+            var pill = document.getElementById('status-pill');
+            if (!pill || typeof Intl === 'undefined' || !Intl.DateTimeFormat) return;
+            var parts = new Intl.DateTimeFormat('en-US', {
+                timeZone: 'America/Chicago',
+                weekday: 'short', hour: '2-digit', minute: '2-digit', hour12: false
+            }).formatToParts(new Date());
+            var f = {};
+            parts.forEach(function (p) { f[p.type] = p.value; });
+            var openDays = { Thu: 1, Fri: 1, Sat: 1, Sun: 1 };
+            var mins = parseInt(f.hour, 10) * 60 + parseInt(f.minute, 10);
+            var isOpen = openDays[f.weekday] && mins >= 18 * 60 && mins < 23 * 60;
+            pill.textContent = isOpen ? 'Open now' : 'Closed now';
+            pill.classList.add(isOpen ? 'is-open' : 'is-closed');
+        } catch (e) { /* keep neutral baseline pill */ }
+    })();
+</script>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -8,7 +8,7 @@
     <meta name="description"
           content="Taqueria Baez Privacy Policy. Learn how we collect, use, and protect your personal information including SMS and text messaging data."/>
     <meta name="robots" content="index, follow"/>
-    <meta name="theme-color" content="#6a1b9a"/>
+    <meta name="theme-color" content="#D7382B"/>
     <link rel="canonical" href="https://www.taqueriabaez.com/privacy-policy"/>
 
     <link rel="icon" type="image/x-icon" href="./assets/img/favicon.ico"/>
@@ -20,12 +20,9 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@500;600&display=swap"
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600&display=swap"
           rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <link rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/css/materialize.min.css">
     <link rel="stylesheet" href="./assets/css/main.css">
 </head>
 
@@ -34,7 +31,11 @@
 <nav class="nav-legal">
     <div class="container">
         <a href="/" class="nav-brand">
-            <i class="material-icons">arrow_back</i>
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <line x1="19" y1="12" x2="5" y2="12"></line>
+                <polyline points="12 19 5 12 12 5"></polyline>
+            </svg>
             Taqueria Baez
         </a>
     </div>
@@ -156,20 +157,16 @@
     </section>
 </main>
 
-<footer class="page-footer mt-0 pt-2">
-    <div class="container">
-        <h5>Taqueria Baez</h5>
-        <p>Where every salsa tells a spicy story!</p>
-        <div class="footer-links">
-            <a href="/privacy-policy">Privacy Policy</a>
-            <a href="/terms">Terms &amp; Conditions</a>
-        </div>
-    </div>
-    <div class="footer-copyright p-0">
-        <div class="container center">&copy; 2025 Taqueria Baez LLC</div>
-    </div>
+<footer class="site-footer">
+    <p class="footer-name">Taqueria Baez</p>
+    <p class="footer-address">2020 Azle Ave, Fort Worth, TX 76164</p>
+    <p><a href="tel:+16822307062">(682) 230-7062</a></p>
+    <nav class="footer-links" aria-label="Legal">
+        <a href="/privacy-policy">Privacy Policy</a>
+        <a href="/terms">Terms &amp; Conditions</a>
+    </nav>
+    <p class="footer-copy">&copy; 2026 Taqueria Baez LLC</p>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/js/materialize.min.js"></script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://taqueriabaez.com/</loc>
-    <lastmod>2025-12-04</lastmod>
+    <loc>https://www.taqueriabaez.com/</loc>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://taqueriabaez.com/privacy-policy</loc>
+    <loc>https://www.taqueriabaez.com/privacy-policy</loc>
     <lastmod>2026-06-05</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://taqueriabaez.com/terms</loc>
+    <loc>https://www.taqueriabaez.com/terms</loc>
     <lastmod>2026-06-05</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
     <meta name="description"
           content="Taqueria Baez SMS Terms and Conditions. Review the terms for our text messaging program including message frequency, opt-out instructions, and data rates."/>
     <meta name="robots" content="index, follow"/>
-    <meta name="theme-color" content="#6a1b9a"/>
+    <meta name="theme-color" content="#D7382B"/>
     <link rel="canonical" href="https://www.taqueriabaez.com/terms"/>
 
     <link rel="icon" type="image/x-icon" href="./assets/img/favicon.ico"/>
@@ -20,12 +20,9 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@500;600&display=swap"
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600&display=swap"
           rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <link rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/css/materialize.min.css">
     <link rel="stylesheet" href="./assets/css/main.css">
 </head>
 
@@ -34,7 +31,11 @@
 <nav class="nav-legal">
     <div class="container">
         <a href="/" class="nav-brand">
-            <i class="material-icons">arrow_back</i>
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <line x1="19" y1="12" x2="5" y2="12"></line>
+                <polyline points="12 19 5 12 12 5"></polyline>
+            </svg>
             Taqueria Baez
         </a>
     </div>
@@ -136,20 +137,16 @@
     </section>
 </main>
 
-<footer class="page-footer mt-0 pt-2">
-    <div class="container">
-        <h5>Taqueria Baez</h5>
-        <p>Where every salsa tells a spicy story!</p>
-        <div class="footer-links">
-            <a href="/privacy-policy">Privacy Policy</a>
-            <a href="/terms">Terms &amp; Conditions</a>
-        </div>
-    </div>
-    <div class="footer-copyright p-0">
-        <div class="container center">&copy; 2025 Taqueria Baez LLC</div>
-    </div>
+<footer class="site-footer">
+    <p class="footer-name">Taqueria Baez</p>
+    <p class="footer-address">2020 Azle Ave, Fort Worth, TX 76164</p>
+    <p><a href="tel:+16822307062">(682) 230-7062</a></p>
+    <nav class="footer-links" aria-label="Legal">
+        <a href="/privacy-policy">Privacy Policy</a>
+        <a href="/terms">Terms &amp; Conditions</a>
+    </nav>
+    <p class="footer-copy">&copy; 2026 Taqueria Baez LLC</p>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/@materializecss/materialize@2.2.2/dist/js/materialize.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

The food truck's move to **2020 Azle Ave** is complete, so the home page changes from a "we're moving" announcement into a permanent, customer-facing **"Find Us"** page focused on the three things people look up: **location, phone, and hours**.

Built on top of `main` (including the recent Twilio A2P 10DLC privacy/terms commit) — Hector's legal pages and compliance footer links are preserved, and both legal pages are restyled to match the new look.

## Home page (`index.html`)
- Clean, **light, mobile-first** layout: location / phone / hours as large tappable rows, an embedded **keyless Google Map**, and `Get Directions` / `Call` actions.
- **Removed Materialize CSS + Material Icons**; replaced with a hand-written light theme (`main.css`) and inline SVG icons. Activated the already-bundled **Anton** font via `@font-face` (one fewer dependency).
- Progressive-enhancement script shows live **Open now / Closed now** in `America/Chicago`; the page is fully functional with JS disabled.

## Legal pages (`privacy-policy.html`, `terms.html`)
- Fully restyled to the new light theme. **Body copy is preserved verbatim** (TCPA/CTIA compliance language) — only presentation changed. Dropped Materialize/Material Icons; back-link uses an inline SVG.
- Privacy Policy / Terms footer links remain on **every** page.

## Consistency / SEO
- JSON-LD `@type` corrected from the invalid `"Food Truck"` → `FoodEstablishment`.
- WCAG AA link-contrast fix (added a darker `--accent-text`), `<time>` markup, and other review findings.
- `site.webmanifest`, `theme-color`, all canonicals, JSON-LD URLs, and every `sitemap.xml` `<loc>` aligned to the **`www`** host.
- Adds `CLAUDE.md`.

## How it was built
A design panel generated/judged layout concepts; a multi-dimension review (a11y, responsive, SEO, correctness, UX) adversarially verified each finding. Verified visually via headless-Chrome screenshots at 320/360/390/768px for all three pages.

## ⚠️ Note for reviewer
The legal pages' in-content date reads **"Effective Date: June 5, 2025 — Last Updated: June 5, 2025"** (carried over verbatim from the existing pages). Given the pages were authored in 2026, that may be a typo — left unchanged since it's legal content. Confirm whether it should be 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dynamic business hours status indicator that displays current open/closed status
  * Enhanced Progressive Web App (PWA) configuration with app metadata and icons

* **Style**
  * Complete visual redesign from dark theme to light, minimal aesthetic
  * Refreshed header, footer, and navigation styling across all pages

* **Documentation**
  * Added development guidelines documentation

* **Chores**
  * Updated domain references and site metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->